### PR TITLE
Allow local recursive requests

### DIFF
--- a/named.conf.options
+++ b/named.conf.options
@@ -21,7 +21,8 @@ options {
 	//========================================================================
 	dnssec-validation no;
 //	Whom do we allow to resolve 3rd party domains to us. Needs zone ".".
-	allow-recursion { ::1;127.0.0.1;};
+        recursion yes;
+        allow-recursion { ::1; 127.0.0.1; 10.0.0.0/8; 172.16.0.0/12; 192.168.0.0/16; };
 //	We close AXFR by default. Here you could list all your secondary DNS IPs
 	allow-transfer { none; };
 


### PR DESCRIPTION
By default BIND now drops recursive requests.
Update named.conf.local to enable recursive requests from RFC 1918 internal networks.